### PR TITLE
Support rooms with spaces in their names (and other special characters)

### DIFF
--- a/includes/event-payload.php
+++ b/includes/event-payload.php
@@ -14,7 +14,7 @@ class WP_Better_HipChat_Event_Payload {
 	public function get_url() {
 		return add_query_arg(
 			array( 'auth_token' => $this->setting['auth_token'] ),
-			sprintf( 'https://api.hipchat.com/v2/room/%s/notification', $this->setting['room'] )
+			sprintf( 'https://api.hipchat.com/v2/room/%s/notification', rawurlencode($this->setting['room'] ))
 		);
 	}
 


### PR DESCRIPTION
Without this HipChat just returns a "Bad Request" 400 status if the room name contains a space.
