### PR TITLE
Specify Own Post Types

### DIFF
--- a/includes/event-manager.php
+++ b/includes/event-manager.php
@@ -22,8 +22,6 @@ class WP_Better_HipChat_Event_Manager {
 	 */
 	private function dispatch_events() {
 
-		$events = $this->get_events();
-
 		// Get all integration settings.
 		// @todo Adds get_posts method into post type
 		// that caches the results.
@@ -47,6 +45,8 @@ class WP_Better_HipChat_Event_Manager {
 			if ( empty( $setting['events'] ) ) {
 				continue;
 			}
+            
+            $events = $this->get_events($setting);
 
 			// For each checked event calls the callback, that's,
 			// hooking into event's action-name to let notifier
@@ -69,16 +69,17 @@ class WP_Better_HipChat_Event_Manager {
 	 * @return array
 	 */
 	public function get_events() {
+        
+        $notified_post_types = apply_filters( 'hipchat_event_transition_post_status_post_types',
+            $setting['types']
+        );
+        
 		return apply_filters( 'hipchat_get_events', array(
 			'post_published' => array(
 				'action'      => 'transition_post_status',
 				'description' => __( 'When a post is published', 'better-hipchat' ),
 				'default'     => true,
-				'message'     => function( $new_status, $old_status, $post ) {
-					$notified_post_types = apply_filters( 'hipchat_event_transition_post_status_post_types', array(
-						'post',
-					) );
-
+				'message'     => function( $new_status, $old_status, $post ) use ( $notified_post_types ) {
 					if ( ! in_array( $post->post_type, $notified_post_types ) ) {
 						return false;
 					}
@@ -108,11 +109,7 @@ class WP_Better_HipChat_Event_Manager {
 				'action'      => 'transition_post_status',
 				'description' => __( 'When a post needs review', 'better-hipchat' ),
 				'default'     => false,
-				'message'     => function( $new_status, $old_status, $post ) {
-					$notified_post_types = apply_filters( 'hipchat_event_transition_post_status_post_types', array(
-						'post',
-					) );
-
+				'message'     => function( $new_status, $old_status, $post ) use ( $notified_post_types ) {
 					if ( ! in_array( $post->post_type, $notified_post_types ) ) {
 						return false;
 					}
@@ -142,14 +139,10 @@ class WP_Better_HipChat_Event_Manager {
 				'action'      => 'wp_insert_comment',
 				'description' => __( 'When there is a new comment', 'better-hipchat' ),
 				'default'     => false,
-				'message'     => function( $comment_id, $comment ) {
+				'message'     => function( $comment_id, $comment ) use ( $notified_post_types ) {
 					$comment = is_object( $comment ) ? $comment : get_comment( absint( $comment ) );
 					$post_id = $comment->comment_post_ID;
-
-					$notified_post_types = apply_filters( 'hipchat_event_wp_insert_comment_post_types', array(
-						'post',
-					) );
-
+                    
 					if ( ! in_array( get_post_type( $post_id ), $notified_post_types ) ) {
 						return false;
 					}

--- a/includes/event-manager.php
+++ b/includes/event-manager.php
@@ -68,7 +68,7 @@ class WP_Better_HipChat_Event_Manager {
 	 *
 	 * @return array
 	 */
-	public function get_events() {
+	public function get_events($setting) {
 
 		$notified_post_types = apply_filters( 'hipchat_event_transition_post_status_post_types',
 			$setting['types']

--- a/includes/event-manager.php
+++ b/includes/event-manager.php
@@ -45,8 +45,8 @@ class WP_Better_HipChat_Event_Manager {
 			if ( empty( $setting['events'] ) ) {
 				continue;
 			}
-            
-            $events = $this->get_events($setting);
+
+			$events = $this->get_events($setting);
 
 			// For each checked event calls the callback, that's,
 			// hooking into event's action-name to let notifier
@@ -69,11 +69,11 @@ class WP_Better_HipChat_Event_Manager {
 	 * @return array
 	 */
 	public function get_events() {
-        
-        $notified_post_types = apply_filters( 'hipchat_event_transition_post_status_post_types',
-            $setting['types']
-        );
-        
+
+		$notified_post_types = apply_filters( 'hipchat_event_transition_post_status_post_types',
+			$setting['types']
+		);
+
 		return apply_filters( 'hipchat_get_events', array(
 			'post_published' => array(
 				'action'      => 'transition_post_status',
@@ -142,7 +142,7 @@ class WP_Better_HipChat_Event_Manager {
 				'message'     => function( $comment_id, $comment ) use ( $notified_post_types ) {
 					$comment = is_object( $comment ) ? $comment : get_comment( absint( $comment ) );
 					$post_id = $comment->comment_post_ID;
-                    
+					
 					if ( ! in_array( get_post_type( $post_id ), $notified_post_types ) ) {
 						return false;
 					}

--- a/includes/post-meta-box.php
+++ b/includes/post-meta-box.php
@@ -99,6 +99,9 @@ class WP_Better_HipChat_Post_Meta_Box {
 		$fields = array(
 			'auth_token'  => 'sanitize_text_field',
 			'room'        => 'sanitize_text_field',
+            'types'       => function ( $val ) {
+                return explode( ',', $val );
+            },
 			'active'      => function( $val ) {
 				if ( $val ) {
 					return true;

--- a/includes/post-meta-box.php
+++ b/includes/post-meta-box.php
@@ -100,7 +100,7 @@ class WP_Better_HipChat_Post_Meta_Box {
 			'auth_token'  => 'sanitize_text_field',
 			'room'        => 'sanitize_text_field',
 			'types'       => function ( $val ) {
-				return explode( ',', $val );
+				return explode( ',', sanitize_text_field($val) );
 			},
 			'active'      => function( $val ) {
 				if ( $val ) {

--- a/includes/post-meta-box.php
+++ b/includes/post-meta-box.php
@@ -99,9 +99,9 @@ class WP_Better_HipChat_Post_Meta_Box {
 		$fields = array(
 			'auth_token'  => 'sanitize_text_field',
 			'room'        => 'sanitize_text_field',
-            'types'       => function ( $val ) {
-                return explode( ',', $val );
-            },
+			'types'       => function ( $val ) {
+				return explode( ',', $val );
+			},
 			'active'      => function( $val ) {
 				if ( $val ) {
 					return true;

--- a/views/post-meta-box.php
+++ b/views/post-meta-box.php
@@ -23,8 +23,8 @@
 				</p>
 			</td>
 		</tr>
-        
-        <tr valign="top">
+		
+		<tr valign="top">
 			<th scope="row">
 				<label for="hipchat_setting[types]"><?php _e( 'Post Types', 'better-hipchat' ); ?></label>
 			</th>
@@ -35,7 +35,6 @@
 				</p>
 			</td>
 		</tr>
-
 
 		<tr valign="top">
 			<th scope="row">

--- a/views/post-meta-box.php
+++ b/views/post-meta-box.php
@@ -23,6 +23,19 @@
 				</p>
 			</td>
 		</tr>
+        
+        <tr valign="top">
+			<th scope="row">
+				<label for="hipchat_setting[types]"><?php _e( 'Post Types', 'better-hipchat' ); ?></label>
+			</th>
+			<td>
+				<input type="text" class="regular-text" name="hipchat_setting[types]" id="hipchat_setting[types]" value="<?php echo ! empty( $setting['types'] ) ? esc_attr( implode( ',', $setting['types']) ) : ''; ?>">
+				<p class="description">
+					<?php _e( 'Comma-separated list of post types to notify on (none by default).', 'better-hipchat' ); ?>
+				</p>
+			</td>
+		</tr>
+
 
 		<tr valign="top">
 			<th scope="row">


### PR DESCRIPTION
Just a small addition I ended up needing today and thought I'd pass across in case it was useful.

It simply adds an extra field to the settings for each Integration which is a comma-separated list of post types.  These post types are then used as the $notified_post_types currently referenced by the existing notifications.

I wasn't particularly sure what to do with the get_events() call in dispatch_events(), but the way I've done it seems to be the cleanest way to get said data into the callbacks for the hooks :smile: 

It probably could do with some kind of means to add the post type to the notification output, but that was beyond the scope of what I needed.  I'm not aware of any complications this causes elsewhere, it's been firing off notifications fine on this end all afternoon!
