### PR TITLE
Adding color and content options. version 0.1.1

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -1,31 +1,36 @@
+label,
+.label {
+  font-weight:        bold;
+}
+
 #hipchat_submitdiv .inside {
-	margin: 0;
-	padding: 0;
+	margin:             0;
+	padding:            0;
 }
 
 #hipchat-test-notify {
-	width: 290px;
-	height: 32px;
+	width:              290px;
+	height:             32px;
 }
 
 #hipchat-test-notify-button {
-	float: left;
+	float:              left;
 }
 
 #hipchat-test-notify .spinner {
-	display: none;
+	display:            none;
 }
 
 .post-type-hipchat_integration .column-events ul {
-	margin: 0;
-	list-style-type: disc;
+	margin:             0;
+	list-style-type:    disc;
 }
 
 .post-type-hipchat_integration .column-events li {
-	margin-left: 1em;
+	margin-left:        1em;
 }
 
 .post-type-hipchat_integration .inactive .column-title strong,
 .post-type-hipchat_integration .inactive .column-title strong a {
-	font-weight: 100;
+	font-weight:        100;
 }

--- a/includes/event-manager.php
+++ b/includes/event-manager.php
@@ -70,6 +70,39 @@ class WP_Better_HipChat_Event_Manager {
 	 */
 	public function get_events() {
 		return apply_filters( 'hipchat_get_events', array(
+			'post_scheduled' => array(
+				'action'      => 'transition_post_status',
+				'description' => __( 'When a post is scheduled', 'better-hipchat' ),
+				'default'     => true,
+				'message'     => function( $new_status, $old_status, $post ) {
+					$notified_post_types = apply_filters( 'hipchat_event_transition_post_status_post_types', array(
+						'post',
+					) );
+
+					if ( ! in_array( $post->post_type, $notified_post_types ) ) {
+						return false;
+					}
+
+					if ( 'future' !== $old_status && 'future' === $new_status ) {
+						$excerpt = has_excerpt( $post->ID ) ?
+							apply_filters( 'get_the_excerpt', $post->post_excerpt )
+							:
+							wp_trim_words( strip_shortcodes( $post->post_content ), 55, '&hellip;' );
+
+						return sprintf(
+							'Scheduled: <a href="%1$s"><strong>%2$s</strong></a> by <strong>%3$s</strong>
+							<br>
+							<pre>%4$s</pre>
+							',
+
+							esc_attr( get_permalink( $post->ID ) ),
+							esc_html( get_the_title( $post->ID ) ),
+							get_the_author_meta( 'display_name', $post->post_author ),
+							apply_filters( 'get_the_excerpt', $excerpt )
+						);
+					}
+				},
+			),
 			'post_published' => array(
 				'action'      => 'transition_post_status',
 				'description' => __( 'When a post is published', 'better-hipchat' ),

--- a/includes/event-manager.php
+++ b/includes/event-manager.php
@@ -90,7 +90,7 @@ class WP_Better_HipChat_Event_Manager {
 							wp_trim_words( strip_shortcodes( $post->post_content ), 55, '&hellip;' );
 
 						return sprintf(
-							'New post published: <a href="%1$s"><strong>%2$s</strong></a> by <strong>%3$s</strong>
+							'New: <a href="%1$s"><strong>%2$s</strong></a> by <strong>%3$s</strong>
 							<br>
 							<pre>%4$s</pre>
 							',
@@ -124,7 +124,7 @@ class WP_Better_HipChat_Event_Manager {
 							wp_trim_words( strip_shortcodes( $post->post_content ), 55, '&hellip;' );
 
 						return sprintf(
-							'New post needs review: <a href="%1$s"><strong>%2$s</strong></a> by <strong>%3$s</strong>
+							'Review: <a href="%1$s"><strong>%2$s</strong></a> by <strong>%3$s</strong>
 							<br>
 							<pre>%4$s</pre>
 							',
@@ -189,6 +189,10 @@ class WP_Better_HipChat_Event_Manager {
 			}
 
 			if ( ! empty( $message ) ) {
+
+			  // process the message based on showcontent preference
+			  $message = ( empty($setting['showcontent']) || $setting['showcontent'] == 'yes' ) ? $message : preg_replace('#<pre>(.*?)</pre>#i','',$message);
+
 				$setting['message'] = $message;
 
 				$notifier->notify( new WP_Better_HipChat_Event_Payload( $setting ) );

--- a/includes/event-payload.php
+++ b/includes/event-payload.php
@@ -14,14 +14,17 @@ class WP_Better_HipChat_Event_Payload {
 	public function get_url() {
 		return add_query_arg(
 			array( 'auth_token' => $this->setting['auth_token'] ),
-			sprintf( 'https://api.hipchat.com/v2/room/%s/notification', rawurlencode($this->setting['room'] ))
+			sprintf( 'https://api.hipchat.com/v2/room/%s/notification', $this->setting['room'] )
 		);
 	}
 
 	public function toJSON() {
 		return json_encode( array(
-			'notify'  => true,
-			'message' => $this->setting['message'],
+		  'from'        => get_bloginfo( 'name' ),
+		  'color'       => $this->setting['color'],
+		  'showcontent' => $this->setting['showcontent'],
+			'notify'      => true,
+			'message'     => $this->setting['message'],
 		) );
 	}
 }

--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -18,7 +18,7 @@ class WP_Better_HipChat_Plugin {
 	public function run( $path ) {
 		// Basic plugin information.
 		$this->name    = 'wp_better_hipchat'; // This maybe used to prefix options, slug of menu or page, and filters/actions.
-		$this->version = '0.1.0';
+		$this->version = '0.1.1';
 
 		// Path.
 		$this->plugin_path   = trailingslashit( plugin_dir_path( $path ) );

--- a/includes/post-meta-box.php
+++ b/includes/post-meta-box.php
@@ -99,6 +99,8 @@ class WP_Better_HipChat_Post_Meta_Box {
 		$fields = array(
 			'auth_token'  => 'sanitize_text_field',
 			'room'        => 'sanitize_text_field',
+			'color'       => 'sanitize_text_field',
+			'showcontent' => 'sanitize_text_field',
 			'active'      => function( $val ) {
 				if ( $val ) {
 					return true;
@@ -138,8 +140,10 @@ class WP_Better_HipChat_Post_Meta_Box {
 	public function ajax_test_notify() {
 		try {
 			$expected_params = array(
-				'auth_token',
-				'room',
+          'auth_token',
+          'room',
+          'color',
+          'showcontent',
 				'test_notify_nonce',
 			);
 			foreach ( $expected_params as $param ) {
@@ -153,9 +157,11 @@ class WP_Better_HipChat_Post_Meta_Box {
 			}
 
 			$payload = array(
-				'auth_token' => $_REQUEST['auth_token'],
-				'room'       => $_REQUEST['room'],
-				'message'    => __( 'Test sending payload!', 'better-hipchat' ),
+				'auth_token'  => $_REQUEST['auth_token'],
+				'room'        => $_REQUEST['room'],
+				'color'       => $_REQUEST['color'],
+				'showcontent' => $_REQUEST['showcontent'],
+				'message'     => __( 'Test sending payload!', 'better-hipchat' ),
 			);
 
 			$resp = $this->plugin->notifier->notify( new WP_Better_HipChat_Event_Payload( $payload ) );

--- a/includes/post-type.php
+++ b/includes/post-type.php
@@ -349,9 +349,11 @@ class WP_Better_HipChat_Post_Type {
 	public function columns_header( $columns ) {
 		unset( $columns['date'] );
 
-		$columns['auth_token'] = __( 'Auth Token', 'better-hipchat' );
-		$columns['room']       = __( 'Room', 'better-hipchat' );
-		$columns['events']     = __( 'Notified Events', 'better-hipchat' );
+		$columns['auth_token']  = __( 'Auth Token', 'better-hipchat' );
+		$columns['room']        = __( 'Room', 'better-hipchat' );
+		$columns['color']       = __( 'Notification Color', 'better-hipchat' );
+		$columns['showcontent'] = __( 'Show Content', 'better-hipchat' );
+		$columns['events']      = __( 'Notified Events', 'better-hipchat' );
 
 		return $columns;
 	}
@@ -372,6 +374,12 @@ class WP_Better_HipChat_Post_Type {
 				break;
 			case 'room':
 				echo ! empty( $setting['room'] ) ? $setting['room'] : '';
+				break;
+			case 'color':
+				echo ! empty( $setting['color'] ) ? $setting['color'] : '';
+				break;
+			case 'showcontent':
+				echo ! empty( $setting['showcontent'] ) ? $setting['showcontent'] : '';
 				break;
 			case 'events':
 				$events = $this->plugin->event_manager->get_events();

--- a/js/admin.js
+++ b/js/admin.js
@@ -24,6 +24,8 @@
 				'action'           : 'hipchat_test_notify',
 				'auth_token'       : $('[name="hipchat_setting[auth_token]"]').val(),
 				'room'             : $('[name="hipchat_setting[room]"]').val(),
+				'color'            : $('[name="hipchat_setting[color]"]').val(),
+				'showcontent'      : $('[name="hipchat_setting[showcontent]"]').val(),
 				'test_notify_nonce': $('#hipchat-test-notify-nonce').val()
 			}
 		} );

--- a/views/post-meta-box.php
+++ b/views/post-meta-box.php
@@ -1,10 +1,8 @@
 <table class="form-table">
 	<tbody>
 		<tr valign="top">
-			<th scope="row">
-				<label for="hipchat_setting[auth_token]"><?php _e( 'Auth Token', 'better-hipchat' ); ?></label>
-			</th>
-			<td>
+			<td colspan="2">
+				<label for="hipchat_setting[auth_token]"><?php _e( 'Auth Token', 'better-hipchat' ); ?></label><br />
 				<input type="text" class="regular-text" name="hipchat_setting[auth_token]" id="hipchat_setting[auth_token]" value="<?php echo ! empty( $setting['auth_token'] ) ? esc_attr( $setting['auth_token'] ) : ''; ?>">
 				<p class="description">
 					<?php _e( 'To get auth token, go to <code>https://SUBDOMAIN.hipchat.com/admin/rooms</code> (replace <code>SUBDOMAIN</code> with your HipChat\'s subdomain). Click the room that you want to be notified. On the left sidebar there\'s Tokens link where you can', 'better-hipchat' ); ?>
@@ -13,22 +11,18 @@
 		</tr>
 
 		<tr valign="top">
-			<th scope="row">
-				<label for="hipchat_setting[room]"><?php _e( 'Room Name', 'better-hipchat' ); ?></label>
-			</th>
-			<td>
+			<td colspan="2">
+				<label for="hipchat_setting[room]"><?php _e( 'Room Name', 'better-hipchat' ); ?></label><br />
 				<input type="text" class="regular-text" name="hipchat_setting[room]" id="hipchat_setting[room]" value="<?php echo ! empty( $setting['room'] ) ? esc_attr( $setting['room'] ) : ''; ?>">
 				<p class="description">
-					<?php _e( 'Room\'s name in which notification will be sent to.', 'better-hipchat' ); ?>
+					<?php _e( 'Room\'s name in which notification will be sent to (ie: 10101010).', 'better-hipchat' ); ?>
 				</p>
 			</td>
 		</tr>
 
 		<tr valign="top">
-			<th scope="row">
-				<?php _e( 'Events to Notify', 'better-hipchat' ); ?>
-			</th>
-			<td>
+			<td colspan="2" class="label">
+				<?php _e( 'Events to Notify', 'better-hipchat' ); ?><br />
 				<?php foreach ( $events as $event => $e ) : ?>
 					<?php
 					$field         = "hipchat_setting[events][$event]";
@@ -44,11 +38,50 @@
 			</td>
 		</tr>
 
+<?php /* additional options */ ?>
 		<tr valign="top">
-			<th scope="row">
-				<label for="hipchat_setting[active]"><?php _e( 'Active', 'better-hipchat' ); ?></label>
-			</th>
 			<td>
+				<label for="hipchat_setting[color]"><?php _e( 'Notification Color', 'better-hipchat' ); ?></label><br />
+			  <?php
+			    $bhcColors = array('yellow', 'green', 'red', 'purple', 'gray', 'random');
+			    $currentColor = !empty( $setting['color'] ) ? esc_attr( $setting['color'] ) : 'yellow'
+			  ?>
+			  <select class="regular-text" name="hipchat_setting[color]" id="hipchat_setting[color]" >
+			    <?php
+			      foreach( $bhcColors as $color ) {
+			        $selected = ( $currentColor == $color ) ? "selected='selected'" : "";
+              echo "<option value='".$color."' ".$selected.">".$color."</option>";
+            }
+			    ?>
+			  </select>
+				<p class="description">
+					<?php _e( 'The color of the notification. Default is yellow.', 'better-hipchat' ); ?>
+				</p>
+			</td>
+			<td>
+				<label for="hipchat_setting[showcontent]"><?php _e( 'Show Content', 'better-hipchat' ); ?></label><br />
+			  <?php
+			    $bhcContentOptions = array('yes', 'no');
+			    $currentContentOption = !empty( $setting['showcontent'] ) ? esc_attr( $setting['showcontent'] ) : 'yes'
+			  ?>
+			  <select class="regular-text" name="hipchat_setting[showcontent]" id="hipchat_setting[showcontent]" >
+			    <?php
+			      foreach( $bhcContentOptions as $option ) {
+			        $selected = ( $currentContentOption == $option ) ? "selected='selected'" : "";
+              echo "<option value='".$option."' ".$selected.">".$option."</option>";
+            }
+			    ?>
+			  </select>
+				<p class="description">
+					<?php _e( 'Show post content in notification. Default is yes.', 'better-hipchat' ); ?>
+				</p>
+			</td>
+		</tr>
+<?php /* end additional options */ ?>
+
+		<tr valign="top">
+			<td>
+				<label for="hipchat_setting[active]"><?php _e( 'Active', 'better-hipchat' ); ?></label><br />
 				<input type="checkbox" name="hipchat_setting[active]" id="hipchat_setting[active]" <?php checked( ! empty( $setting['active'] ) ? $setting['active'] : false ); ?>>
 				<p class="description">
 					<?php _e( 'Notification will not be sent if not checked.', 'better-hipchat' ); ?>
@@ -58,8 +91,7 @@
 
 		<?php if ( 'publish' === $post->post_status ) : ?>
 		<tr valign="top">
-			<th scope="row"></th>
-			<td>
+			<td colspan="2">
 				<div id="hipchat-test-notify">
 					<input id="hipchat-test-notify-nonce" type="hidden" value="<?php echo esc_attr( wp_create_nonce( 'test_notify_nonce' ) ); ?>">
 					<button class="button" id="hipchat-test-notify-button"><?php _e( 'Test send notification with this setting.', 'better-hipchat' ); ?></button>


### PR DESCRIPTION
Added UI to be able to select colors (based on HipChat API v2) and whether the content of the post is displayed or not. There were issues in our use case that made the content too long for our workflow. 

Default color is 'yellow', and default show content is 'yes'. 

Additionally, the name of the blog is added after 'User'. In our case we have a multi-stack, and knowing at a glance the blog name is helpful.
